### PR TITLE
DBT-392 add properties for EAH Jena DOIs

### DIFF
--- a/src/main/resources/config/dbt/mycore.properties
+++ b/src/main/resources/config/dbt/mycore.properties
@@ -70,7 +70,6 @@ MCR.PI.MetadataService.Uni-Weimar-MODSURN.Prefix=urn\:nbn\:de\:gbv\:wim2-
 MCR.PI.Generator.Uni-Weimar-DOI=org.mycore.pi.doi.MCRMapObjectIDDOIGenerator
 MCR.PI.Generator.Uni-Weimar-DOI.Prefix.dbt_mods=%MCR.PI.MetadataService.Uni-Weimar-MODSDOI.Prefix%/dbt.
 
-
 MCR.PI.Service.Uni-Weimar-Datacite=org.mycore.pi.doi.MCRDOIService
 MCR.PI.Service.Uni-Weimar-Datacite.MetadataService=Uni-Weimar-MODSDOI
 MCR.PI.Service.Uni-Weimar-Datacite.Generator=Uni-Weimar-DOI
@@ -95,8 +94,28 @@ MCR.PI.Service.Uni-Weimar-DNBURN.Generator=Uni-Weimar-URN
 MCR.PI.Service.Uni-Weimar-DNBURN.MetadataService=Uni-Weimar-MODSURN
 
 # EAH Jena
+MCR.PI.MetadataService.EAH-Jena-MODSDOI=org.mycore.mods.identifier.MCRMODSDOIMetadataService
+MCR.PI.MetadataService.EAH-Jena-MODSDOI.Prefix=10.82528
+
 MCR.PI.MetadataService.EAH-Jena-MODSURN=org.mycore.mods.identifier.MCRMODSURNMetadataService
 MCR.PI.MetadataService.EAH-Jena-MODSURN.Prefix=urn\:nbn\:de\:gbv\:j59-
+
+MCR.PI.Generator.EAH-Jena-DOI=org.mycore.pi.doi.MCRMapObjectIDDOIGenerator
+MCR.PI.Generator.EAH-Jena-DOI.Prefix.dbt_mods=%MCR.PI.MetadataService.EAH-Jena-MODSDOI.Prefix%/dbt.
+
+MCR.PI.Service.EAH-Jena-Datacite=org.mycore.pi.doi.MCRDOIService
+MCR.PI.Service.EAH-Jena-Datacite.MetadataService=EAH-Jena-MODSDOI
+MCR.PI.Service.EAH-Jena-Datacite.Generator=EAH-Jena-DOI
+MCR.PI.Service.EAH-Jena-Datacite.RegisterBaseURL=%MCR.PI.Service.Datacite.RegisterBaseURL%
+MCR.PI.Service.EAH-Jena-Datacite.Username=""
+MCR.PI.Service.EAH-Jena-Datacite.Password=""
+MCR.PI.Service.EAH-Jena-Datacite.UseTestServer=%MCR.PI.Service.Datacite.UseTestPrefix%
+MCR.PI.Service.EAH-Jena-Datacite.Transformer=datacite
+MCR.PI.Service.EAH-Jena-Datacite.JobApiUser=%MCR.PI.Service.Datacite.JobApiUser%
+MCR.PI.Service.EAH-Jena-Datacite.RegistrationPredicate=org.mycore.pi.condition.MCRPIPublishedPredicate
+MCR.PI.Service.EAH-Jena-Datacite.HostingInstitution=Ernst-Abbe-Hochschule Jena
+MCR.PI.Service.EAH-Jena-Datacite.Namespace=http://datacite.org/schema/kernel-4
+MCR.PI.Service.EAH-Jena-Datacite.Schema=xsd/datacite/v4.3/metadata.xsd
 
 MCR.PI.Generator.EAH-Jena-URN=de.urmel_dl.dbt.pi.DBTMapObjectIDURNGenerator
 MCR.PI.Generator.EAH-Jena-URN.Prefix.dbt_mods=%MCR.PI.Generator.EAH-Jena-URN.Namespace%dbt-


### PR DESCRIPTION
This pull request introduces configuration updates to the `mycore.properties` file to support persistent identifier (PI) services for a new institution, EAH Jena. Below is a breakdown of the most important changes:

### Configuration updates for EAH Jena:

* Added metadata service configuration for EAH Jena's MODS DOI, including the service class and DOI prefix. (`src/main/resources/config/dbt/mycore.properties`, [src/main/resources/config/dbt/mycore.propertiesR97-R119](diffhunk://#diff-25bbe3859a195f2174ddc1d1920c60240eecb3c1e50abd7234b35023bd07aab4R97-R119))
* Added generator configuration for EAH Jena's DOI, linking it to the MODS DOI prefix. (`src/main/resources/config/dbt/mycore.properties`, [src/main/resources/config/dbt/mycore.propertiesR97-R119](diffhunk://#diff-25bbe3859a195f2174ddc1d1920c60240eecb3c1e50abd7234b35023bd07aab4R97-R119))
* Configured the Datacite service for EAH Jena, including metadata service, generator, registration details, and associated properties like hosting institution and schema. (`src/main/resources/config/dbt/mycore.properties`, [src/main/resources/config/dbt/mycore.propertiesR97-R119](diffhunk://#diff-25bbe3859a195f2174ddc1d1920c60240eecb3c1e50abd7234b35023bd07aab4R97-R119))
