### PR TITLE
update to mycore-parent 57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.mycore</groupId>
     <artifactId>mycore-parent</artifactId>
-    <version>53</version>
+    <version>57</version>
   </parent>
   <artifactId>dbt-module</artifactId>
   <version>2023.06-SNAPSHOT</version>
@@ -406,8 +406,9 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central-portal-snapshots</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -418,8 +419,9 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central-portal-snapshots</id>
+      <name>Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>


### PR DESCRIPTION
This pull request updates the Maven project configuration in `pom.xml` to use a newer parent version and changes the repository and plugin repository settings to point to a new snapshot repository.

Updates to parent version:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7): Updated the parent version from `53` to `57`, ensuring compatibility with the latest parent project features and dependencies.

Changes to repository settings:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L409-R411): Updated the repository configuration to replace `ossrh` with `central-portal-snapshots`, including a new name and URL for the snapshot repository.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L421-R424): Updated the plugin repository configuration similarly, replacing `ossrh` with `central-portal-snapshots` and adding a new name and URL.