### PR TITLE
DBT-399 disable all text tracks for videos by default

### DIFF
--- a/src/main/media/ts/_player/player.ts
+++ b/src/main/media/ts/_player/player.ts
@@ -235,7 +235,7 @@ export class Player {
                     sources.id,
                     src.src),
                 language: this.extractLanguage(src.src),
-                default: i === 0
+                default: false
             }, true));
         } else {
             this.player.controlBar.subsCapsButton.disable();


### PR DESCRIPTION
This pull request makes a minor change to how subtitle tracks are set in the `Player` class. The change ensures that no subtitle track is marked as default when initializing the player.

* Always sets the `default` property to `false` for subtitle tracks in the `Player` class, instead of marking the first track as default. (`src/main/media/ts/_player/player.ts`)

Disable all text tracks (captions and subtitles) for videos by default in the media player. This change ensures that subtitles do not appear automatically when playing videos, and users must manually enable them through the player controls if they wish to view them. This addresses accessibility and user preference concerns by giving users control over when text tracks are displayed.