### PR TITLE
DBT-400 fix EntityMessageBodyWriter|Reader usage

### DIFF
--- a/src/main/java/de/urmel_dl/dbt/rc/resources/RCResource.java
+++ b/src/main/java/de/urmel_dl/dbt/rc/resources/RCResource.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Optional;
 
+import de.urmel_dl.dbt.rest.utils.EntityMessageBodyBinding;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -45,9 +46,10 @@ import de.urmel_dl.dbt.rc.persistency.SlotManager;
 /**
  * The RC API Resource.
  *
- * @author Ren\u00E9 Adler (eagle)
+ * @author René Adler (eagle)
  *
  */
+@EntityMessageBodyBinding
 @Path("rc")
 public class RCResource {
 

--- a/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyBinding.java
+++ b/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyBinding.java
@@ -1,0 +1,22 @@
+package de.urmel_dl.dbt.rest.utils;
+
+import jakarta.ws.rs.NameBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Name-binding for DBT entity message body providers.
+ * <p>
+ * Use this on JAX-RS resources or methods that must be handled by the
+ * {@link de.urmel_dl.dbt.rest.utils.EntityMessageBodyWriter} and
+ * {@link de.urmel_dl.dbt.rest.utils.EntityMessageBodyReader} instead of other
+ * registered providers (e.g., Jackson).
+ */
+@NameBinding
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EntityMessageBodyBinding {
+}

--- a/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyReader.java
+++ b/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyReader.java
@@ -22,7 +22,9 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -39,6 +41,8 @@ import de.urmel_dl.dbt.utils.EntityFactory;
  * @param <T> the generic type
  */
 @Provider
+@EntityMessageBodyBinding
+@Priority(Priorities.USER)
 @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 public class EntityMessageBodyReader<T> implements MessageBodyReader<T> {
 

--- a/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyWriter.java
+++ b/src/main/java/de/urmel_dl/dbt/rest/utils/EntityMessageBodyWriter.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -38,6 +40,8 @@ import de.urmel_dl.dbt.utils.EntityFactory;
  *
  */
 @Provider
+@EntityMessageBodyBinding
+@Priority(Priorities.USER)
 @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 public class EntityMessageBodyWriter<T> implements MessageBodyWriter<T> {
 
@@ -66,7 +70,7 @@ public class EntityMessageBodyWriter<T> implements MessageBodyWriter<T> {
     public void writeTo(T t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
         MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
         throws IOException, WebApplicationException {
-        if (mediaType.equals(MediaType.APPLICATION_JSON_TYPE)) {
+        if (MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
             new EntityFactory<>(t).toJSON(entityStream);
             return;
         }


### PR DESCRIPTION
This pull request introduces a custom JAX-RS name binding annotation to ensure that specific message body readers and writers are used for certain resources, instead of default providers like Jackson. It also updates the JSON media type compatibility check and makes minor documentation and import improvements.

**JAX-RS Entity Message Body Handling:**
* Added a new annotation `EntityMessageBodyBinding` to explicitly bind resources or methods to custom entity message body providers, ensuring that `EntityMessageBodyReader` and `EntityMessageBodyWriter` are used instead of other providers.
* Applied the `@EntityMessageBodyBinding` annotation to the `RCResource` class, as well as to the `EntityMessageBodyReader` and `EntityMessageBodyWriter` classes, to enforce the use of these providers for relevant endpoints [[1]](diffhunk://#diff-5b0ed112c9044fdd1bad7b2a8f7a6f7bd9470d6587aa5fe3474573f50911355bL48-R52) [[2]](diffhunk://#diff-1daabedad3aa1c781c0291fb9e59d3ae596748ea2662f46ae852f68daa357fb8R44-R45) [[3]](diffhunk://#diff-f063bcf498dc060d692f990d4f478dbd6d1619451072f73b6e339c670c57943fR43-R44).
* Set `@Priority(Priorities.USER)` on both the reader and writer to control provider selection order [[1]](diffhunk://#diff-1daabedad3aa1c781c0291fb9e59d3ae596748ea2662f46ae852f68daa357fb8R44-R45) [[2]](diffhunk://#diff-f063bcf498dc060d692f990d4f478dbd6d1619451072f73b6e339c670c57943fR43-R44).

**Improvements and Fixes:**
* Improved the JSON media type check in `EntityMessageBodyWriter` to use `isCompatible` instead of `equals`, making the check more robust for different JSON subtypes.

**Minor Changes:**
* Fixed author name encoding in the JavaDoc of `RCResource` and added missing imports in several files [[1]](diffhunk://#diff-5b0ed112c9044fdd1bad7b2a8f7a6f7bd9470d6587aa5fe3474573f50911355bR26) [[2]](diffhunk://#diff-1daabedad3aa1c781c0291fb9e59d3ae596748ea2662f46ae852f68daa357fb8R25-R27) [[3]](diffhunk://#diff-f063bcf498dc060d692f990d4f478dbd6d1619451072f73b6e339c670c57943fR26-R27).